### PR TITLE
ci(github): Implement the libgodot-build/action.yml

### DIFF
--- a/.github/actions/libgodot-build/action.yml
+++ b/.github/actions/libgodot-build/action.yml
@@ -1,0 +1,23 @@
+name: Build libgodot
+description: Build libgodot with the provided options.
+inputs:
+  bin:
+    description: Path to the Godot binary.
+    required: true
+  target:
+    description: The scons target (debug/release).
+    default: "debug"
+  platform:
+    description: The libgodot platform to build.
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - name: Generate api.json
+      shell: sh
+      run: ${{ inputs.bin }} --no-window --audio-driver Dummy --gdnative-generate-json-api ./bin/api.json
+      continue-on-error: true
+
+    - name: Scons Build
+      shell: sh
+      run: scons --directory=modules/gdnative/binding p=${{ inputs.platform }} target=${{ inputs.target }} --jobs=2

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,6 +1,12 @@
 name: 🏁 Windows Builds
 on:
   workflow_call:
+  workflow_dispatch:
+    inputs:
+      libgodot-build:
+        description: If libgodot is to be built.
+        default: false
+        type: boolean
 
 # Global Settings
 # SCONS_CACHE for windows must be set in the build environment
@@ -23,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor (target=release_debug, tools=yes vsproj=yes)
+          - name: Editor (target=release_debug, tools=yes, vsproj=yes)
             cache-name: windows-editor
             target: release_debug
             tools: true
@@ -72,3 +78,18 @@ jobs:
         uses: ./.github/actions/upload-artifact
         with:
           name: ${{ matrix.cache-name }}
+
+      - name: Compilation (libgodot)
+        if: ${{ github.event.inputs.libgodot-build && matrix.tools }}
+        uses: ./.github/actions/libgodot-build
+        with:
+          bin: ${{ matrix.bin }}
+          target: release
+          platform: windows
+
+      - name: Upload artifact (libgodot)
+        if: ${{ github.event.inputs.libgodot-build && matrix.tools }}
+        uses: ./.github/actions/upload-artifact
+        with:
+          name: windows-libgodot
+          path: "modules/gdnative/binding/bin/*"


### PR DESCRIPTION
https://github.com/Watunder/NEO-DOT/actions/runs/16976803176

need another pr to implement build `debug|release` libs and upload `include|bin` dirs