### PR TITLE
ci(github): Bump official actions to run on Node 24

### DIFF
--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Restore .scons_cache directory
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ inputs.scons-cache }}
         key: ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Save .scons_cache directory
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ inputs.scons-cache }}
         key: ${{ inputs.cache-name }}-${{ env.GODOT_BASE_BRANCH }}-${{ github.ref }}-${{ github.sha }}

--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     # Use python 3.x release (works cross platform)
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         # Semantic version range syntax or exact version of a Python version
         python-version: ${{ inputs.python-version }}

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Upload Godot Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/emscripten_builds.yml
+++ b/.github/workflows/emscripten_builds.yml
@@ -33,7 +33,7 @@ jobs:
             tools: no
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore

--- a/.github/workflows/plugin_builds.yml
+++ b/.github/workflows/plugin_builds.yml
@@ -51,7 +51,7 @@ jobs:
       matrix: ${{ fromJSON(needs.define-matrix.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps
@@ -68,7 +68,7 @@ jobs:
           path-type: inherit
 
       - name: Download artifact (libgodot)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           run-id: ${{ inputs.windows-builds-id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_runner.yml
+++ b/.github/workflows/pr_runner.yml
@@ -38,7 +38,7 @@ jobs:
     needs: emscripten-build
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           name: emscripten-editor

--- a/.github/workflows/push_checks.yml
+++ b/.github/workflows/push_checks.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Check for open PRs
         id: check-prs
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -42,7 +42,7 @@ jobs:
             tools: no
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/